### PR TITLE
Fix missing version check

### DIFF
--- a/game/source_engine_nav.ksy
+++ b/game/source_engine_nav.ksy
@@ -369,6 +369,7 @@ types:
       # Ladders
       - id: ladder_data
         type: area_id_array
+        if: '_root.version >= 6'
         repeat: expr
         repeat-expr: 2
       # Occupy times


### PR DESCRIPTION
Fix missing version check for `navarea.ladder_data` field.
Allow to parse CS 1.6/CSCZ nav files.
Tested via Kaitai Web IDE.